### PR TITLE
Incorrect artifact name when path contains repository name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ matrix:
   - os: linux
     dist: bionic
     env:
-      - ARTIFACT_PUBLICATION=false
-      - NEXUS_VERSION=latest
-      - NEXUS_API_VERSION=v1
-  - os: linux
-    dist: bionic
-    env:
       - ARTIFACT_PUBLICATION=true
       - NEXUS_VERSION=3.16.2
       - NEXUS_API_VERSION=v1

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -137,7 +137,7 @@ func (n Nexus3) artifactName(url string) (string, string, error) {
 		return "", "", errors.New(url + " is not an URL")
 	}
 
-	re := regexp.MustCompile("^.*/" + n.Repository + "/(.*)/(.+)$")
+	re := regexp.MustCompile("^.*?/" + n.Repository + "/(.*)/(.+)$")
 	match := re.FindStringSubmatch(url)
 	if match == nil {
 		return "", "", errors.New("URL: '" + url + "' does not seem to contain an artifactName")

--- a/cli/backup_test.go
+++ b/cli/backup_test.go
@@ -124,6 +124,23 @@ func TestArtifactName(t *testing.T) {
 	}
 }
 
+func TestArtifactNameContainingRepositoryName(t *testing.T) {
+	actualDir, actualFile, _ := n.artifactName("http://localhost:9999/repository/maven-releases/com/maven-releases/tools/1.0.0/tools-1.0.0.jar")
+	expectedDir := "com/maven-releases/tools/1.0.0"
+	expectedFile := "tools-1.0.0.jar"
+
+	if expectedDir != actualDir || expectedFile != actualFile {
+		t.Errorf("Dir and file incorrect. Expected: %v & %v. Actual: %v & %v", expectedDir, expectedFile, actualDir, actualFile)
+	}
+
+	_, _, actualError := n.artifactName("some-url")
+	expectedError := "some-url is not an URL"
+
+	if actualError.Error() != expectedError {
+		t.Errorf(errMsgTxt, expectedError, actualError)
+	}
+}
+
 func TestCreateArtifact(t *testing.T) {
 	actualErrorFile := createArtifact("testFiles", "file100/file100", "some-content")
 	expectedErrorFile := "open testFiles/file100/file100: no such file or directory"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When backing up an artifact whose path contains repository name, artifact path on disk is incorrect

**Which issue(s) this PR fixes**:

Fixes #75

