### PR TITLE
Add flag "insecureSkipVerify" to skip the repository certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Flags:
   -v, --apiVersion string   The Nexus3 APIVersion, e.g. v1 or beta (default "v1")
   -d, --debug               Enable debug logging
   -h, --help                help for n3dr
+      --insecureSkipVerify  Skip repository certificate check
   -p, --n3drPass string     The Nexus3 password
   -n, --n3drURL string      The Nexus3 URL
   -u, --n3drUser string     The Nexus3 user
@@ -129,6 +130,17 @@ running the following command:
 
 ```
 ./n3dr-linux upload -u admin -n http://localhost:8081 -r maven-public
+```
+
+## "Clone" the content of a repository in a different Nexus 3 server in a different repository 
+
+This is the basic steps to "clone" and eventually rename the content of a repository from one nexus3 server to another server in a different repository name
+
+```
+./n3dr-linux backup -u <source nexus3 user> -n <source nexus3 server url> -r <repo-source-name>
+cd download
+mv <repo-source-name> <repo-target-name>
+./n3dr-linux upload -u <target nexus3 user> -n <target nexus3 server url> -r <repo-target-name>
 ```
 
 ## Rationale for N3DR

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"net/http"
+	"crypto/tls"
 
 	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
@@ -26,7 +28,7 @@ import (
 
 var (
 	apiVersion, cfgFile, n3drRepo, n3drURL, n3drUser, Version string
-	debug, zip                                                bool
+	debug, zip, insecureSkipVerify                            bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -55,6 +57,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "enable debug logging")
 	rootCmd.PersistentFlags().BoolVarP(&zip, "zip", "z", false, "add downloaded artifacts to a ZIP archive")
+	rootCmd.PersistentFlags().BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "Skip repository certificate check")
 
 	rootCmd.PersistentFlags().StringP("n3drPass", "p", "", "nexus3 password")
 	rootCmd.PersistentFlags().StringVarP(&n3drURL, "n3drURL", "n", "", "nexus3 URL")
@@ -89,6 +92,12 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		log.Warn("~/.n3dr.yaml does not exist or yaml is invalid")
 	}
+
+	if insecureSkipVerify {
+		log.Warn("Certificate validity check is disabled!")
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
 }
 
 func enableDebug() {


### PR DESCRIPTION
Partially addresses #107

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This adds a global flag "-insecureSkipVerify" to skik the repository certificate validations

**Which issue(s) this PR fixes**:
 Partially #107

**Special notes for your reviewer**:
