### PR TITLE
Select multiple repositories for backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ the following command is run:
 n3dr backup -u admin -n http://localhost:8081 -r maven-releases
 ```
 
+### Backup artifacts from a repositories list
+
+All artifacts from a repositories list will be stored in a download folder when
+the following command is run:
+
+```
+n3dr backup -u admin -n http://localhost:8081 -r maven-releases,maven-private
+```
+
 ### Backup all repositories
 
 All artifacts from various repositories will be stored in a download

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"n3dr/cli"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -21,13 +22,16 @@ reside in a certain Nexus3 repository`,
 			log.Fatal(err)
 		}
 
-		n := cli.Nexus3{URL: n3drURL, User: n3drUser, Pass: n3drPass, Repository: n3drRepo, APIVersion: apiVersion, ZIP: zip, ZipName: zipName}
-		if err := n.StoreArtifactsOnDisk(dir, regex); err != nil {
-			log.Fatal(err)
-		}
-
-		if err := n.CreateZip(dir); err != nil {
-			log.Fatal(err)
+		selectedRepositories := strings.Split(n3drRepo, ",")
+		for _, repository := range selectedRepositories {
+			log.Info("Processing repository: ", repository)
+			n := cli.Nexus3{URL: n3drURL, User: n3drUser, Pass: n3drPass, Repository: repository, APIVersion: apiVersion, ZIP: zip, ZipName: zipName}
+			if err := n.StoreArtifactsOnDisk(dir, regex); err != nil {
+				log.Fatal(err)
+			}
+			if err := n.CreateZip(dir); err != nil {
+				log.Fatal(err)
+			}
 		}
 	},
 	Version: rootCmd.Version,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

<https://github.com/030/n3dr/blob/master/CONTRIBUTING.md/>

-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
I'd like to execute n3dr once to download all repositories I want, but `n3dr repositories` command is not an option, because I don't want to download public mirrors and unsupported repositories.

**Which issue(s) this PR fixes**:

Fixes #149

**Special notes for your reviewer**:
Examples:
- single:
```
$ ./n3dr-dev-linux -u nexus-backup -n https://nexus-dev backup -r repo1 
INFO[0000] n3drHomeDir: '/Users/volodymyr.soloviov/.n3dr' 
INFO[0000] Using config file: '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] n3drPass empty. Reading if from '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] Temp download dir name: '/tmp/n3dr/download478446615' 
INFO[0000] Processing repository: repo1                 
INFO[0007] Assembling downloadURLs 'repo1'              
 3 / 3 [====================================================================================================================================================] 100.00% 6s
Done
INFO[0014] Backing up artifacts 'repo1'                 
 24 / 24 [=================================================================================================================================================] 100.00% 38s
Done
```

- multiple:
```
$ ./n3dr-dev-linux -u nexus-backup -n https://nexus-dev backup -r repo1,repo2 
INFO[0000] n3drHomeDir: '/Users/volodymyr.soloviov/.n3dr' 
INFO[0000] Using config file: '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] n3drPass empty. Reading if from '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] Temp download dir name: '/tmp/n3dr/download339525433' 
INFO[0000] Processing repository: repo1                 
INFO[0007] Assembling downloadURLs 'repo1'              
 3 / 3 [====================================================================================================================================================] 100.00% 6s
Done
INFO[0014] Backing up artifacts 'repo1'                 
 24 / 24 [=================================================================================================================================================] 100.00% 30s
Done
INFO[0044] Processing repository: repo2                 
INFO[0051] Assembling downloadURLs 'repo2'              
 2 / 2 [====================================================================================================================================================] 100.00% 4s
Done
INFO[0056] Backing up artifacts 'repo2'                 
 18 / 18 [=================================================================================================================================================] 100.00% 23s
Done
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support to specify a list of repositories in `-r` separated by comma, e.g. `-r repo1,repo2. 
```
