### PR TITLE
Add --directory-prefix. The directory prefix is the directory where a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,15 @@ Available Commands:
   upload       Upload all artifacts to a specific Nexus3 repository
 
 Flags:
-  -v, --apiVersion string   The Nexus3 APIVersion, e.g. v1 or beta (default "v1")
-  -d, --debug               Enable debug logging
-  -h, --help                help for n3dr
-      --insecureSkipVerify  Skip repository certificate check
-  -p, --n3drPass string     The Nexus3 password
-  -n, --n3drURL string      The Nexus3 URL
-  -u, --n3drUser string     The Nexus3 user
-  -z, --zip                 Add downloaded artifacts to a ZIP archive
+  -v, --apiVersion string        The Nexus3 APIVersion, e.g. v1 or beta (default "v1")
+  -d, --debug                    Enable debug logging
+  -h, --help                     help for n3dr
+      --insecureSkipVerify       Skip repository certificate check
+  -p, --n3drPass string          The Nexus3 password
+  -n, --n3drURL string           The Nexus3 URL
+  -u, --n3drUser string          The Nexus3 user
+  -z, --zip                      Add downloaded artifacts to a ZIP archive
+      --directory-prefix string  The directory prefix is the directory where artifacts will be saved    
 
 Use "n3dr [command] --help" for more information about a command.
 ```

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -32,7 +32,14 @@ const (
 	tmpDir      = "/tmp/n3dr"
 )
 
-func TempDownloadDir() (string, error) {
+func TempDownloadDir(downloadDirName string) (string, error) {
+	if downloadDirName != "" {
+		if err := os.MkdirAll(downloadDirName, os.ModePerm); err != nil {
+			return "", nil
+		}
+		log.Infof("Download dir name: '%v'", downloadDirName)
+		return downloadDirName, nil
+	}
 	if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
 		return "", nil
 	}

--- a/cli/common.go
+++ b/cli/common.go
@@ -28,13 +28,14 @@ const (
 
 // Nexus3 contains the attributes that are used by several functions
 type Nexus3 struct {
-	URL        string
-	User       string
-	Pass       string
-	Repository string
-	APIVersion string
-	ZIP        bool
-	ZipName    string
+	URL             string
+	User            string
+	Pass            string
+	Repository      string
+	APIVersion      string
+	ZIP             bool
+	ZipName         string
+	DownloadDirName string
 }
 
 func (n Nexus3) validate() {

--- a/cli/repositories.go
+++ b/cli/repositories.go
@@ -44,7 +44,7 @@ func (n Nexus3) CountRepositories() error {
 
 // Downloads retrieves artifacts from all repositories
 func (n Nexus3) Downloads(regex string) error {
-	dir, err := TempDownloadDir()
+	dir, err := TempDownloadDir(n.DownloadDirName)
 	if err != nil {
 		return err
 	}

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -17,7 +17,7 @@ var backupCmd = &cobra.Command{
 	Long: `Use this command in order to backup all artifacts that
 reside in a certain Nexus3 repository`,
 	Run: func(cmd *cobra.Command, args []string) {
-		dir, err := cli.TempDownloadDir()
+		dir, err := cli.TempDownloadDir(downloadDirName)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -38,7 +38,7 @@ reside in a certain Nexus3 repository`,
 }
 
 func init() {
-	backupCmd.PersistentFlags().StringVarP(&n3drRepo, "n3drRepo", "r", "", "nexus3 repository")
+	backupCmd.PersistentFlags().StringVarP(&n3drRepo, "n3drRepo", "r", "", "nexus3 repositories")
 	backupCmd.Flags().StringVarP(&regex, "regex", "x", ".*", "only download artifacts that match a regular expression, e.g. 'some/group42'")
 
 	if err := backupCmd.MarkPersistentFlagRequired("n3drRepo"); err != nil {

--- a/cmd/repositories.go
+++ b/cmd/repositories.go
@@ -26,7 +26,7 @@ download artifacts from all repositories`,
 			}
 			log.Fatal("One of the required flags \"names\", \"count\" or \"backup\" not set")
 		}
-		n := cli.Nexus3{URL: n3drURL, User: n3drUser, Pass: n3drPass, APIVersion: apiVersion, ZIP: zip, ZipName: zipName}
+		n := cli.Nexus3{URL: n3drURL, User: n3drUser, Pass: n3drPass, APIVersion: apiVersion, ZIP: zip, ZipName: zipName, DownloadDirName: downloadDirName}
 		if names {
 			if err := n.RepositoryNames(); err != nil {
 				log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	apiVersion, cfgFile, n3drRepo, n3drURL, n3drPass, n3drUser, Version, zipName string
-	anonymous, debug, zip, insecureSkipVerify                                    bool
+	apiVersion, cfgFile, n3drRepo, n3drURL, n3drPass, n3drUser, Version, zipName, downloadDirName string
+	anonymous, debug, zip, insecureSkipVerify                                                     bool
 )
 
 var rootCmd = &cobra.Command{
@@ -46,6 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&n3drPass, "n3drPass", "p", "", "nexus3 password")
 	rootCmd.PersistentFlags().StringVarP(&n3drURL, "n3drURL", "n", "", "nexus3 URL")
 	rootCmd.PersistentFlags().StringVarP(&n3drUser, "n3drUser", "u", "", "nexus3 user")
+	rootCmd.PersistentFlags().StringVar(&downloadDirName, "directory-prefix", "", "directory to store downloaded artifacts")
 	rootCmd.PersistentFlags().StringVarP(&apiVersion, "apiVersion", "v", "v1", "nexus3 APIVersion, e.g. v1 or beta")
 	rootCmd.PersistentFlags().BoolVar(&anonymous, "anonymous", false, "Skip authentication")
 }


### PR DESCRIPTION
…rtifacts will be saved

<!--  Thanks for sending a pull request!  Here are some tips for you:

<https://github.com/030/n3dr/blob/master/CONTRIBUTING.md/>

-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

https://github.com/030/n3dr/pull/141 introduced destination directory changes. This feature is awesome for full backups, but not for incrementals.

For incremental backups it skips downloading artifact if it exists and local checksum matches to the checksum reported by Nexus: https://github.com/030/n3dr/blob/master/cli/backup.go#L145 . Incremental backups are much faster because it doesn't re-download artifact it already has locally. It was introduced in [#121](https://github.com/030/n3dr/pull/121/files#diff-2dd5766d31c54c6514541bb279f12b48R141)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #151

**Special notes for your reviewer**:
Examples:
- no `--directory-prefix`:
```
$ ./n3dr-dev-linux -u nexus-backup -n https://nexus-dev backup -r repo1,repo2 
INFO[0000] n3drHomeDir: '/Users/volodymyr.soloviov/.n3dr' 
INFO[0000] Using config file: '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] n3drPass empty. Reading if from '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] Temp download dir name: '/tmp/n3dr/download326179707' 
INFO[0000] Processing repository: repo1                 
INFO[0006] Assembling downloadURLs 'repo1'              
 3 / 3 [====================================================================================================================================================] 100.00% 6s
Done
INFO[0013] Backing up artifacts 'repo1'                 
 24 / 24 [=================================================================================================================================================] 100.00% 12s
Done
INFO[0026] Processing repository: repo2                 
INFO[0030] Assembling downloadURLs 'repo2'              
 2 / 2 [====================================================================================================================================================] 100.00% 5s
Done
INFO[0035] Backing up artifacts 'repo2'                 
 18 / 18 [=================================================================================================================================================] 100.00% 12s
Done

```

- with `--directory-prefix`:
```
$ ./n3dr-dev-linux -u nexus-backup -n https://nexus-dev backup -r repo1,repo2 --directory-prefix download/ 
INFO[0000] n3drHomeDir: '/Users/volodymyr.soloviov/.n3dr' 
INFO[0000] Using config file: '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] n3drPass empty. Reading if from '/Users/volodymyr.soloviov/.n3dr/config.yml' 
INFO[0000] Download dir name: 'download/'               
INFO[0000] Processing repository: repo1                 
INFO[0006] Assembling downloadURLs 'repo1'              
 3 / 3 [====================================================================================================================================================] 100.00% 7s
Done
INFO[0014] Backing up artifacts 'repo1'                 
 24 / 24 [==================================================================================================================================================] 100.00% 9s
Done
INFO[0023] Processing repository: repo2                 
INFO[0029] Assembling downloadURLs 'repo2'              
 2 / 2 [====================================================================================================================================================] 100.00% 4s
Done
INFO[0034] Backing up artifacts 'repo2'                 
 18 / 18 [==================================================================================================================================================] 100.00% 6s
Done

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added --directory-prefix. The directory prefix is the directory where artifacts will be saved
```
