### PR TITLE
Add uploading of Android libraries and Kotlin Multiplatform artifacts

### DIFF
--- a/configs/swagger/nexus3.json
+++ b/configs/swagger/nexus3.json
@@ -1982,6 +1982,28 @@
             "description": "maven2 Asset 10 Extension",
             "required": false,
             "type": "string"
+          },
+
+          {
+            "name": "maven2.asset11",
+            "in": "formData",
+            "description": "maven2 Asset 11",
+            "required": false,
+            "type": "file"
+          },
+          {
+            "name": "maven2.asset11.classifier",
+            "in": "formData",
+            "description": "maven2 Asset 11 Classifier",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "maven2.asset11.extension",
+            "in": "formData",
+            "description": "maven2 Asset 11 Extension",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -17,7 +17,7 @@ curl http://localhost:8081/service/rest/swagger.json -o \
 
 Lookup the `maven2.asset3` json snippet, septuple it and change it to:
 `maven2.asset4`, `maven2.asset5`, `maven2.asset6`, `maven2.asset7`,
-`maven2.asset8`, `maven2.asset9` and `maven2.asset10` respectively. After
+`maven2.asset8`, `maven2.asset9`, `maven2.asset10` and `maven2.asset11` respectively. After
 adding the seven snippets and renaming them, download go-swagger and generate
 internal go-swagger code:
 

--- a/internal/app/n3dr/artifactsv2/upload/upload.go
+++ b/internal/app/n3dr/artifactsv2/upload/upload.go
@@ -29,7 +29,7 @@ import (
 )
 
 type artifactFiles struct {
-	f2, f3, f4, f5, f6, f7 *os.File
+	f2, f3, f4, f5, f6, f7, f8, f9, f10, f11 *os.File
 }
 
 type mavenParts struct {
@@ -293,12 +293,82 @@ func (af artifactFiles) mavenJarAndOtherExtensions(c *components.UploadComponent
 		}).Trace("Maven2 asset6")
 	}
 
+	filePathAar := fileNameWithoutExtIncludingDir + ".aar"
+	if _, err := os.Stat(filePathAar); err == nil {
+		af.f8, err = os.Open(filepath.Clean(filePathAar))
+		if err != nil {
+			return err
+		}
+		c.Maven2Asset8 = af.f8
+		ext8 := "aar"
+		c.Maven2Asset8Extension = &ext8
+
+		log.WithFields(log.Fields{
+			"file":      c.Maven2Asset8.Name(),
+			"extension": *c.Maven2Asset8Extension,
+		}).Trace("Maven2 asset8")
+	}
+
+	filePathKotlinToolingMetadata := fileNameWithoutExtIncludingDir + "-kotlin-tooling-metadata.json"
+	if _, err := os.Stat(filePathKotlinToolingMetadata); err == nil {
+		af.f9, err = os.Open(filepath.Clean(filePathKotlinToolingMetadata))
+		if err != nil {
+			return err
+		}
+		c.Maven2Asset9 = af.f9
+		ext9 := "json"
+		c.Maven2Asset9Extension = &ext9
+		classifier9 := "kotlin-tooling-metadata"
+		c.Maven2Asset9Classifier = &classifier9
+
+		log.WithFields(log.Fields{
+			"file":       c.Maven2Asset9.Name(),
+			"extension":  *c.Maven2Asset9Extension,
+			"classifier": *c.Maven2Asset9Classifier,
+		}).Trace("Maven2 asset9")
+	}
+
+	filePathMetadata := fileNameWithoutExtIncludingDir + "-metadata.jar"
+	if _, err := os.Stat(filePathMetadata); err == nil {
+		af.f10, err = os.Open(filepath.Clean(filePathMetadata))
+		if err != nil {
+			return err
+		}
+		c.Maven2Asset10 = af.f10
+		ext10 := "jar"
+		c.Maven2Asset10Extension = &ext10
+		classifier10 := "metadata"
+		c.Maven2Asset10Classifier = &classifier10
+
+		log.WithFields(log.Fields{
+			"file":       c.Maven2Asset10.Name(),
+			"extension":  *c.Maven2Asset10Extension,
+			"classifier": *c.Maven2Asset10Classifier,
+		}).Trace("Maven2 asset10")
+	}
+
+	filePathKlib := fileNameWithoutExtIncludingDir + ".klib"
+	if _, err := os.Stat(filePathKlib); err == nil {
+		af.f11, err = os.Open(filepath.Clean(filePathKlib))
+		if err != nil {
+			return err
+		}
+		c.Maven2Asset11 = af.f11
+		ext11 := "klib"
+		c.Maven2Asset11Extension = &ext11
+
+		log.WithFields(log.Fields{
+			"file":       c.Maven2Asset11.Name(),
+			"extension":  *c.Maven2Asset11Extension,
+		}).Trace("Maven2 asset11")
+	}
+
 	return nil
 }
 
 func removeExtension(fileName string) string {
 	ext := filepath.Ext(fileName)
-	re := regexp.MustCompile(`(-[a-zA-Z]+)?` + ext + `$`)
+	re := regexp.MustCompile(`(-[a-zA-Z]+)*\` + ext + `$`)
 	result := re.ReplaceAllString(fileName, "")
 	filename := filepath.Base(result)
 	return filename
@@ -415,6 +485,10 @@ func (n *Nexus3) UploadSingleArtifact(client *client.Nexus3, path, localDiskRepo
 			maven2Asset5 := "empty"
 			maven2Asset6 := "empty"
 			maven2Asset7 := "empty"
+			maven2Asset8 := "empty"
+			maven2Asset9 := "empty"
+			maven2Asset10 := "empty"
+			maven2Asset11 := "empty"
 
 			if c.Maven2Asset1 != nil {
 				maven2Asset1 = c.Maven2Asset1.Name()
@@ -437,15 +511,31 @@ func (n *Nexus3) UploadSingleArtifact(client *client.Nexus3, path, localDiskRepo
 			if c.Maven2Asset7 != nil {
 				maven2Asset7 = c.Maven2Asset7.Name()
 			}
+			if c.Maven2Asset8 != nil {
+				maven2Asset8 = c.Maven2Asset8.Name()
+			}
+			if c.Maven2Asset9 != nil {
+				maven2Asset9 = c.Maven2Asset9.Name()
+			}
+			if c.Maven2Asset10 != nil {
+				maven2Asset10 = c.Maven2Asset10.Name()
+			}
+			if c.Maven2Asset11 != nil {
+				maven2Asset11 = c.Maven2Asset11.Name()
+			}
 
 			log.WithFields(log.Fields{
-				"1": maven2Asset1,
-				"2": maven2Asset2,
-				"3": maven2Asset3,
-				"4": maven2Asset4,
-				"5": maven2Asset5,
-				"6": maven2Asset6,
-				"7": maven2Asset7,
+				"1":  maven2Asset1,
+				"2":  maven2Asset2,
+				"3":  maven2Asset3,
+				"4":  maven2Asset4,
+				"5":  maven2Asset5,
+				"6":  maven2Asset6,
+				"7":  maven2Asset7,
+				"8":  maven2Asset8,
+				"9":  maven2Asset9,
+				"10": maven2Asset10,
+				"11": maven2Asset11,
 			}).Debug("Maven2 asset upload")
 		} else {
 			log.Debugf("folder: '%s' does not contain a pom file: '%s'", dirPath, filePathPom)
@@ -486,7 +576,7 @@ func (n *Nexus3) UploadSingleArtifact(client *client.Nexus3, path, localDiskRepo
 			generatePOM := true
 			c.Maven2GeneratePom = &generatePOM
 
-			maven2Asset1, maven2Asset2, maven2Asset3, maven2Asset4, maven2Asset5, maven2Asset6, maven2Asset7 := "empty", "empty", "empty", "empty", "empty", "empty", "empty"
+			maven2Asset1, maven2Asset2, maven2Asset3, maven2Asset4, maven2Asset5, maven2Asset6, maven2Asset7, maven2Asset8, maven2Asset9, maven2Asset10, maven2Asset11 := "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty"
 
 			if c.Maven2Asset1 != nil {
 				maven2Asset1 = c.Maven2Asset1.Name()
@@ -509,15 +599,31 @@ func (n *Nexus3) UploadSingleArtifact(client *client.Nexus3, path, localDiskRepo
 			if c.Maven2Asset7 != nil {
 				maven2Asset7 = c.Maven2Asset7.Name()
 			}
+			if c.Maven2Asset8 != nil {
+				maven2Asset8 = c.Maven2Asset8.Name()
+			}
+			if c.Maven2Asset9 != nil {
+				maven2Asset9 = c.Maven2Asset9.Name()
+			}
+			if c.Maven2Asset10 != nil {
+				maven2Asset10 = c.Maven2Asset10.Name()
+			}
+			if c.Maven2Asset11 != nil {
+				maven2Asset11 = c.Maven2Asset11.Name()
+			}
 
 			log.WithFields(log.Fields{
-				"1": maven2Asset1,
-				"2": maven2Asset2,
-				"3": maven2Asset3,
-				"4": maven2Asset4,
-				"5": maven2Asset5,
-				"6": maven2Asset6,
-				"7": maven2Asset7,
+				"1":  maven2Asset1,
+				"2":  maven2Asset2,
+				"3":  maven2Asset3,
+				"4":  maven2Asset4,
+				"5":  maven2Asset5,
+				"6":  maven2Asset6,
+				"7":  maven2Asset7,
+				"8":  maven2Asset8,
+				"9":  maven2Asset9,
+				"10": maven2Asset10,
+				"11": maven2Asset11,
 			}).Debug("Maven2 asset upload")
 		}
 
@@ -570,7 +676,7 @@ func (n *Nexus3) UploadSingleArtifact(client *client.Nexus3, path, localDiskRepo
 		return false, nil
 	}
 
-	files := []*os.File{f, af.f2, af.f3, af.f4, af.f5, af.f6, af.f2, af.f7}
+	files := []*os.File{f, af.f2, af.f3, af.f4, af.f5, af.f6, af.f2, af.f7, af.f8, af.f9, af.f10, af.f11}
 	if err := upload(c, client, path, files); err != nil {
 		return false, err
 	}

--- a/internal/app/n3dr/goswagger/client/components/upload_component_parameters.go
+++ b/internal/app/n3dr/goswagger/client/components/upload_component_parameters.go
@@ -122,6 +122,24 @@ type UploadComponentParams struct {
 	*/
 	Maven2Asset10Extension *string
 
+	/* Maven2Asset11.
+
+	   maven2 Asset 11
+	*/
+	Maven2Asset11 runtime.NamedReadCloser
+
+	/* Maven2Asset11Classifier.
+
+	   maven2 Asset 11 Classifier
+	*/
+	Maven2Asset11Classifier *string
+
+	/* Maven2Asset11Extension.
+
+	   maven2 Asset 11 Extension
+	*/
+	Maven2Asset11Extension *string
+
 	/* Maven2Asset2.
 
 	   maven2 Asset 2
@@ -553,6 +571,39 @@ func (o *UploadComponentParams) WithMaven2Asset10Extension(maven2Asset10Extensio
 // SetMaven2Asset10Extension adds the maven2Asset10Extension to the upload component params
 func (o *UploadComponentParams) SetMaven2Asset10Extension(maven2Asset10Extension *string) {
 	o.Maven2Asset10Extension = maven2Asset10Extension
+}
+
+// WithMaven2Asset11 adds the maven2Asset11 to the upload component params
+func (o *UploadComponentParams) WithMaven2Asset11(maven2Asset11 runtime.NamedReadCloser) *UploadComponentParams {
+	o.SetMaven2Asset11(maven2Asset11)
+	return o
+}
+
+// SetMaven2Asset11 adds the maven2Asset11 to the upload component params
+func (o *UploadComponentParams) SetMaven2Asset11(maven2Asset11 runtime.NamedReadCloser) {
+	o.Maven2Asset11 = maven2Asset11
+}
+
+// WithMaven2Asset11Classifier adds the maven2Asset11Classifier to the upload component params
+func (o *UploadComponentParams) WithMaven2Asset11Classifier(maven2Asset11Classifier *string) *UploadComponentParams {
+	o.SetMaven2Asset11Classifier(maven2Asset11Classifier)
+	return o
+}
+
+// SetMaven2Asset11Classifier adds the maven2Asset11Classifier to the upload component params
+func (o *UploadComponentParams) SetMaven2Asset11Classifier(maven2Asset11Classifier *string) {
+	o.Maven2Asset11Classifier = maven2Asset11Classifier
+}
+
+// WithMaven2Asset11Extension adds the maven2Asset11Extension to the upload component params
+func (o *UploadComponentParams) WithMaven2Asset11Extension(maven2Asset11Extension *string) *UploadComponentParams {
+	o.SetMaven2Asset11Extension(maven2Asset11Extension)
+	return o
+}
+
+// SetMaven2Asset11Extension adds the maven2Asset11Extension to the upload component params
+func (o *UploadComponentParams) SetMaven2Asset11Extension(maven2Asset11Extension *string) {
+	o.Maven2Asset11Extension = maven2Asset11Extension
 }
 
 // WithMaven2Asset2 adds the maven2Asset2 to the upload component params
@@ -1178,6 +1229,46 @@ func (o *UploadComponentParams) WriteToRequest(r runtime.ClientRequest, reg strf
 		fMaven2Asset10Extension := frMaven2Asset10Extension
 		if fMaven2Asset10Extension != "" {
 			if err := r.SetFormParam("maven2.asset10.extension", fMaven2Asset10Extension); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Maven2Asset11 != nil {
+
+		if o.Maven2Asset11 != nil {
+			// form file param maven2.asset11
+			if err := r.SetFileParam("maven2.asset11", o.Maven2Asset11); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Maven2Asset11Classifier != nil {
+
+		// form param maven2.asset11.classifier
+		var frMaven2Asset11Classifier string
+		if o.Maven2Asset11Classifier != nil {
+			frMaven2Asset11Classifier = *o.Maven2Asset11Classifier
+		}
+		fMaven2Asset11Classifier := frMaven2Asset11Classifier
+		if fMaven2Asset11Classifier != "" {
+			if err := r.SetFormParam("maven2.asset11.classifier", fMaven2Asset11Classifier); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Maven2Asset11Extension != nil {
+
+		// form param maven2.asset11.extension
+		var frMaven2Asset11Extension string
+		if o.Maven2Asset11Extension != nil {
+			frMaven2Asset11Extension = *o.Maven2Asset11Extension
+		}
+		fMaven2Asset11Extension := frMaven2Asset11Extension
+		if fMaven2Asset11Extension != "" {
+			if err := r.SetFormParam("maven2.asset11.extension", fMaven2Asset11Extension); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Fix restoring backup with Android libraries and Kotlin Multiplatform artifacts (.aar, .klib files and kotlin metadata files).

**Which issue(s) this PR fixes**:

I haven't created an issue.

**Special notes for your reviewer**:

I don't know Go, this is my first time with the language, I hope it doesn't look awful.

 * add uploading of .aar artifacts (Android library)
 * add uploading of .klib and metadata files (Kotlin Multiplatform artifacts)
 * update regex in `removeExtension()` to support name with several hyphens  (like -kotlin-tooling-metadata.json)
 * add asset11 to cover all new files

**Does this PR introduce a user-facing change?**:

```release-note
Add uploading of .aar artifacts (Android library) and .klib and metadata files (Kotlin Multiplatform artifacts).
```
